### PR TITLE
feat: Implementacion de /me y /refresh

### DIFF
--- a/src/main/java/com/sebsrvv/app/config/SecurityConfig.java
+++ b/src/main/java/com/sebsrvv/app/config/SecurityConfig.java
@@ -3,7 +3,6 @@ package com.sebsrvv.app.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -12,35 +11,32 @@ import org.springframework.security.web.SecurityFilterChain;
 @Configuration
 public class SecurityConfig {
 
-    // 1) Todo lo de /api/auth/** es público y NO usa resource server
     @Bean
-    @Order(1)
-    SecurityFilterChain authChain(HttpSecurity http) throws Exception {
+    SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .securityMatcher("/api/auth/**")
                 .csrf(csrf -> csrf.disable())
                 .cors(Customizer.withDefaults())
                 .authorizeHttpRequests(auth -> auth
+                        // Preflight
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-                        .anyRequest().permitAll()
-                );
-        return http.build();
-    }
 
-    // 2) Resto de rutas sí usan resource server
-    @Bean
-    @Order(2)
-    SecurityFilterChain apiChain(HttpSecurity http) throws Exception {
-        http
-                .csrf(csrf -> csrf.disable())
-                .cors(Customizer.withDefaults())
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                        // Actuator
                         .requestMatchers("/actuator/health", "/actuator/info").permitAll()
+
+                        // Auth públicas
+                        .requestMatchers(HttpMethod.POST, "/api/auth/register", "/api/auth/login").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/auth/refresh").permitAll()
+                        .requestMatchers(HttpMethod.GET,  "/api/auth/me").permitAll()
+
+                        // Público extra (si aplica)
                         .requestMatchers(HttpMethod.GET, "/api/metrics").permitAll()
+
+                        // Todo lo demás requiere JWT
                         .anyRequest().authenticated()
                 )
+                // Si tienes otras rutas protegidas con JWT, déjalo activo
                 .oauth2ResourceServer(o -> o.jwt(Customizer.withDefaults()));
+
         return http.build();
     }
 }

--- a/src/main/java/com/sebsrvv/app/config/SecurityConfig.java
+++ b/src/main/java/com/sebsrvv/app/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.sebsrvv.app.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -11,32 +12,35 @@ import org.springframework.security.web.SecurityFilterChain;
 @Configuration
 public class SecurityConfig {
 
+    // 1) Todo lo de /api/auth/** es público y NO usa resource server
     @Bean
-    SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    @Order(1)
+    SecurityFilterChain authChain(HttpSecurity http) throws Exception {
+        http
+                .securityMatcher("/api/auth/**")
+                .csrf(csrf -> csrf.disable())
+                .cors(Customizer.withDefaults())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                        .anyRequest().permitAll()
+                );
+        return http.build();
+    }
+
+    // 2) Resto de rutas sí usan resource server
+    @Bean
+    @Order(2)
+    SecurityFilterChain apiChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
                 .cors(Customizer.withDefaults())
                 .authorizeHttpRequests(auth -> auth
-                        // Preflight
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-
-                        // Actuator
                         .requestMatchers("/actuator/health", "/actuator/info").permitAll()
-
-                        // Auth públicas
-                        .requestMatchers(HttpMethod.POST, "/api/auth/register", "/api/auth/login").permitAll()
-                        .requestMatchers(HttpMethod.POST, "/api/auth/refresh").permitAll()
-                        .requestMatchers(HttpMethod.GET,  "/api/auth/me").permitAll()
-
-                        // Público extra (si aplica)
                         .requestMatchers(HttpMethod.GET, "/api/metrics").permitAll()
-
-                        // Todo lo demás requiere JWT
                         .anyRequest().authenticated()
                 )
-                // Si tienes otras rutas protegidas con JWT, déjalo activo
                 .oauth2ResourceServer(o -> o.jwt(Customizer.withDefaults()));
-
         return http.build();
     }
 }

--- a/src/main/java/com/sebsrvv/app/config/SecurityConfig.java
+++ b/src/main/java/com/sebsrvv/app/config/SecurityConfig.java
@@ -17,22 +17,24 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .cors(Customizer.withDefaults())
                 .authorizeHttpRequests(auth -> auth
-                        // Preflight y estáticos (si los hubiera)
+                        // Preflight
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
 
-                        // Actuator básicos
+                        // Actuator
                         .requestMatchers("/actuator/health", "/actuator/info").permitAll()
 
                         // Auth públicas
                         .requestMatchers(HttpMethod.POST, "/api/auth/register", "/api/auth/login").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/auth/refresh").permitAll()
+                        .requestMatchers(HttpMethod.GET,  "/api/auth/me").permitAll()
 
-                        // ✅ Endpoint PÚBLICO de métricas
+                        // Público extra (si aplica)
                         .requestMatchers(HttpMethod.GET, "/api/metrics").permitAll()
 
                         // Todo lo demás requiere JWT
                         .anyRequest().authenticated()
                 )
-                // Resource server con JWT (para el resto)
+                // Si tienes otras rutas protegidas con JWT, déjalo activo
                 .oauth2ResourceServer(o -> o.jwt(Customizer.withDefaults()));
 
         return http.build();

--- a/src/main/java/com/sebsrvv/app/modules/auth/web/AuthController.java
+++ b/src/main/java/com/sebsrvv/app/modules/auth/web/AuthController.java
@@ -1,10 +1,7 @@
 package com.sebsrvv.app.modules.auth.web;
 
 import com.sebsrvv.app.modules.auth.application.AuthService;
-import com.sebsrvv.app.modules.auth.web.dto.LoginRequest;
-import com.sebsrvv.app.modules.auth.web.dto.LoginResponse;
-import com.sebsrvv.app.modules.auth.web.dto.RegisterRequest;
-import com.sebsrvv.app.modules.auth.web.dto.RegisterResponse;
+import com.sebsrvv.app.modules.auth.web.dto.*;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -16,9 +13,13 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/auth")
 public class AuthController {
+
     private final AuthService authService;
     public AuthController(AuthService authService) { this.authService = authService; }
 
+    /* ---------------------------------------------------------
+     * REGISTER
+     * --------------------------------------------------------- */
     @PostMapping("/register")
     public Mono<ResponseEntity<RegisterResponse>> register(@Valid @RequestBody RegisterRequest r) {
         var payload = Map.<String,Object>of(
@@ -41,6 +42,9 @@ public class AuthController {
                 });
     }
 
+    /* ---------------------------------------------------------
+     * LOGIN
+     * --------------------------------------------------------- */
     @PostMapping("/login")
     public Mono<ResponseEntity<LoginResponse>> login(@Valid @RequestBody LoginRequest r) {
         return authService.login(r.email(), r.password())
@@ -54,5 +58,54 @@ public class AuthController {
                     );
                     return ResponseEntity.ok(resp);
                 });
+    }
+
+    /* ---------------------------------------------------------
+     * REFRESH
+     * --------------------------------------------------------- */
+    @PostMapping("/refresh")
+    public Mono<ResponseEntity<RefreshResponse>> refresh(@Valid @RequestBody RefreshRequest r) {
+        return authService.refresh(r.refreshToken())
+                .map(tokens -> ResponseEntity.ok(
+                        new RefreshResponse(
+                                String.valueOf(tokens.get("access_token")),
+                                String.valueOf(tokens.get("refresh_token")),
+                                String.valueOf(tokens.getOrDefault("token_type", "bearer")),
+                                (Integer) tokens.getOrDefault("expires_in", null),
+                                (Map<String, Object>) tokens.getOrDefault("user", null)
+                        )
+                ));
+    }
+
+    /* ---------------------------------------------------------
+     * ME
+     * --------------------------------------------------------- */
+    @GetMapping("/me")
+    public Mono<ResponseEntity<MeResponse>> me(@RequestHeader(name = "Authorization", required = false) String authHeader) {
+        if (authHeader == null || authHeader.isBlank()) {
+            return Mono.just(ResponseEntity.status(401).build());
+        }
+
+        String token = authHeader.replaceFirst("(?i)^Bearer\\s+", "").trim();
+        if (token.isBlank()) {
+            return Mono.just(ResponseEntity.status(401).build());
+        }
+
+        return authService.getUser(token)
+                .map(user -> {
+                    String id   = String.valueOf(user.get("id"));
+                    String email = String.valueOf(user.get("email"));
+                    String role  = String.valueOf(user.getOrDefault("role", "authenticated"));
+                    @SuppressWarnings("unchecked")
+                    Map<String,Object> appMeta = (Map<String, Object>) user.getOrDefault("app_metadata", Map.of());
+                    @SuppressWarnings("unchecked")
+                    Map<String,Object> userMeta = (Map<String, Object>) user.getOrDefault("user_metadata", Map.of());
+                    String createdAt = String.valueOf(user.getOrDefault("created_at", null));
+                    String updatedAt = String.valueOf(user.getOrDefault("updated_at", null));
+
+                    MeResponse resp = new MeResponse(id, email, role, appMeta, userMeta, createdAt, updatedAt);
+                    return ResponseEntity.ok(resp);
+                })
+                .onErrorResume(ex -> Mono.just(ResponseEntity.status(401).build()));
     }
 }

--- a/src/main/java/com/sebsrvv/app/modules/auth/web/dto/MeResponse.java
+++ b/src/main/java/com/sebsrvv/app/modules/auth/web/dto/MeResponse.java
@@ -1,0 +1,13 @@
+package com.sebsrvv.app.modules.auth.web.dto;
+
+import java.util.Map;
+
+public record MeResponse(
+        String id,
+        String email,
+        String role,
+        Map<String, Object> app_metadata,
+        Map<String, Object> user_metadata,
+        String created_at,
+        String updated_at
+) {}

--- a/src/main/java/com/sebsrvv/app/modules/auth/web/dto/RefreshRequest.java
+++ b/src/main/java/com/sebsrvv/app/modules/auth/web/dto/RefreshRequest.java
@@ -1,0 +1,7 @@
+package com.sebsrvv.app.modules.auth.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RefreshRequest(
+        @NotBlank String refreshToken
+) {}

--- a/src/main/java/com/sebsrvv/app/modules/auth/web/dto/RefreshResponse.java
+++ b/src/main/java/com/sebsrvv/app/modules/auth/web/dto/RefreshResponse.java
@@ -1,0 +1,11 @@
+package com.sebsrvv.app.modules.auth.web.dto;
+
+import java.util.Map;
+
+public record RefreshResponse(
+        String accessToken,
+        String refreshToken,
+        String tokenType,
+        Integer expiresIn,
+        Map<String, Object> user
+) {}

--- a/src/main/java/com/sebsrvv/app/supabase/SupabaseAuthClient.java
+++ b/src/main/java/com/sebsrvv/app/supabase/SupabaseAuthClient.java
@@ -1,4 +1,3 @@
-// supabase/SupabaseAuthClient.java
 package com.sebsrvv.app.supabase;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -7,21 +6,28 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
+
 import java.util.Map;
 
 @Service
 public class SupabaseAuthClient {
-    private final WebClient client;
 
-    public SupabaseAuthClient(@Value("${supabase.url}") String baseUrl,
-                              @Value("${supabase.serviceKey}") String serviceKey) {
-        this.client = WebClient.builder()
-                .baseUrl(baseUrl)
-                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                .defaultHeader("apikey", serviceKey)
-                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + serviceKey)
-                .build();
+    private final WebClient.Builder builder;
+    private final String baseUrl;
+    private final String serviceKey;
+    private final String anonKey;
+
+    public SupabaseAuthClient(WebClient.Builder builder,
+                              @Value("${supabase.url}") String baseUrl,
+                              @Value("${supabase.serviceKey}") String serviceKey,
+                              @Value("${supabase.anonKey}") String anonKey) {
+        this.builder = builder;
+        this.baseUrl = baseUrl;
+        this.serviceKey = serviceKey;
+        this.anonKey = anonKey;
     }
+
+    /** -------------------- ADMIN (service role) -------------------- */
 
     public Mono<Map> adminCreateUser(String email, String password, Map<String,Object> userMeta, boolean emailConfirm) {
         var body = Map.of(
@@ -30,14 +36,71 @@ public class SupabaseAuthClient {
                 "email_confirm", emailConfirm,
                 "user_metadata", userMeta
         );
-        return client.post().uri("/auth/v1/admin/users")
-                .bodyValue(body).retrieve().bodyToMono(Map.class);
+
+        var adminClient = builder
+                .baseUrl(baseUrl)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .defaultHeader("apikey", serviceKey)
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + serviceKey)
+                .build();
+
+        return adminClient.post()
+                .uri("/auth/v1/admin/users")
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(Map.class);
     }
 
-    // opcional: login para emitir token desde backend
+    /** -------------------- USUARIO (anon key) -------------------- */
+
+    // Login (password grant) -> Authorization: Bearer <anonKey>, apikey: <anonKey>
     public Mono<Map> passwordGrant(String email, String password) {
         var body = Map.of("email", email, "password", password);
-        return client.post().uri("/auth/v1/token?grant_type=password")
-                .bodyValue(body).retrieve().bodyToMono(Map.class);
+
+        var publicClient = builder
+                .baseUrl(baseUrl)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .defaultHeader("apikey", anonKey)
+                .build();
+
+        return publicClient.post()
+                .uri("/auth/v1/token?grant_type=password")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + anonKey)
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(Map.class);
+    }
+
+    // Refresh -> Authorization: Bearer <anonKey>, apikey: <anonKey>
+    public Mono<Map> refresh(String refreshToken) {
+        var body = Map.of("refresh_token", refreshToken);
+
+        var publicClient = builder
+                .baseUrl(baseUrl)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .defaultHeader("apikey", anonKey)
+                .build();
+
+        return publicClient.post()
+                .uri("/auth/v1/token?grant_type=refresh_token")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + anonKey)
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(Map.class);
+    }
+
+    // Me -> Authorization: Bearer <accessToken del usuario>, apikey: <anonKey>
+    public Mono<Map> getUser(String accessToken) {
+        var publicClient = builder
+                .baseUrl(baseUrl)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .defaultHeader("apikey", anonKey)
+                .build();
+
+        return publicClient.get()
+                .uri("/auth/v1/user")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .retrieve()
+                .bodyToMono(Map.class);
     }
 }

--- a/src/main/java/com/sebsrvv/app/supabase/SupabaseDataClient.java
+++ b/src/main/java/com/sebsrvv/app/supabase/SupabaseDataClient.java
@@ -1,4 +1,3 @@
-// supabase/SupabaseDataClient.java
 package com.sebsrvv.app.supabase;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -7,16 +6,19 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
+
 import java.util.List;
 import java.util.Map;
 
 @Service
 public class SupabaseDataClient {
+
     private final WebClient rest;
 
-    public SupabaseDataClient(@Value("${supabase.url}") String baseUrl,
+    public SupabaseDataClient(WebClient.Builder builder,
+                              @Value("${supabase.url}") String baseUrl,
                               @Value("${supabase.serviceKey}") String serviceKey) {
-        this.rest = WebClient.builder()
+        this.rest = builder
                 .baseUrl(baseUrl + "/rest/v1")
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .defaultHeader("apikey", serviceKey)
@@ -26,23 +28,35 @@ public class SupabaseDataClient {
     }
 
     public Mono<List> insert(String table, Map<String,Object> row) {
-        return rest.post().uri("/" + table).bodyValue(List.of(row))
-                .retrieve().bodyToMono(List.class);
+        return rest.post()
+                .uri("/" + table)
+                .bodyValue(List.of(row))
+                .retrieve()
+                .bodyToMono(List.class);
     }
 
     public Mono<List> select(String table, String queryParams) {
-        return rest.get().uri("/" + table + (queryParams==null? "": "?" + queryParams))
-                .retrieve().bodyToMono(List.class);
+        String qp = (queryParams == null || queryParams.isBlank()) ? "" : "?" + queryParams;
+        return rest.get()
+                .uri("/" + table + qp)
+                .retrieve()
+                .bodyToMono(List.class);
     }
 
     public Mono<Integer> delete(String table, String queryParams) {
-        return rest.delete().uri("/" + table + "?" + queryParams)
-                .retrieve().toBodilessEntity().map(resp -> resp.getStatusCode().value());
+        return rest.delete()
+                .uri("/" + table + "?" + queryParams)
+                .retrieve()
+                .toBodilessEntity()
+                .map(resp -> resp.getStatusCode().value());
     }
 
     public Mono<List> upsert(String table, Map<String,Object> row) {
-        return rest.post().uri("/" + table)
+        return rest.post()
+                .uri("/" + table)
                 .header("Prefer","resolution=merge-duplicates,return=representation")
-                .bodyValue(List.of(row)).retrieve().bodyToMono(List.class);
+                .bodyValue(List.of(row))
+                .retrieve()
+                .bodyToMono(List.class);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,6 +3,7 @@ spring.application.name=supabase-backend
 # --- Supabase ---
 supabase.url=${SUPABASE_URL}
 supabase.serviceKey=${SUPABASE_SERVICE_ROLE_KEY}
+supabase.anonKey=${SUPABASE_ANON_KEY}
 supabase.profilesTable=profiles
 
 # --- Server ---
@@ -11,7 +12,7 @@ server.port=${PORT:8080}
 # --- Actuator ---
 management.endpoints.web.exposure.include=health,info
 
-# --- JWT ---
+# --- JWT (Resource Server) ---
 spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${supabase.url}/auth/v1/keys
 
 # --- CORS ---


### PR DESCRIPTION
Pull Request: Soporte de Refresh Token y endpoint /me

✅ Separación de clientes WebClient:
- adminHttp con serviceKey para /auth/v1/admin/*
- publicHttp con anonKey para /auth/v1/* de usuario
(logging detallado en ambos)

✅ Nuevo endpoint: POST /api/auth/refresh
- DTOs: RefreshRequest, RefreshResponse
- Flujo de refresh token integrado

✅ Nuevo endpoint: GET /api/auth/me
- Obtiene la información del usuario usando el access_token

✅ Autenticación y manejo de errores mejorados
- Uso del cliente correcto por flujo (login/refresh/user)
- handleTokenResponse unificado
- Mensajes claros para invalid_grant, token vencido o credenciales inválidas

✅ Refactors en AuthService
- Helpers para conversión de tipos, redacción de campos sensibles
- Cálculo de BMI/edad y limpieza del payload

✅ Seguridad (Spring Security)
- Reglas actualizadas para permitir /api/auth/refresh y /api/auth/me sin autenticación
(evitando 401 prematuros del resource server)

✅ Logs
- Trazas de entrada/salida para llamadas a Supabase en clientes público y admin