### PR TITLE
feat(auth): agregar funcionalidad para eliminar cuenta de usuario autentificado

### DIFF
--- a/src/main/java/com/sebsrvv/app/modules/auth/web/dto/DeleteRequest.java
+++ b/src/main/java/com/sebsrvv/app/modules/auth/web/dto/DeleteRequest.java
@@ -1,0 +1,7 @@
+package com.sebsrvv.app.modules.auth.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record DeleteRequest(
+        @NotBlank String confirmation
+) {}

--- a/src/main/java/com/sebsrvv/app/modules/auth/web/dto/DeleteResponse.java
+++ b/src/main/java/com/sebsrvv/app/modules/auth/web/dto/DeleteResponse.java
@@ -1,0 +1,6 @@
+package com.sebsrvv.app.modules.auth.web.dto;
+
+public record DeleteResponse(
+        String status,   // "deleted" | "rejected" | "forbidden"
+        String message
+) {}


### PR DESCRIPTION
Pull Request: Eliminación de cuenta (self-service) con confirmación

✅ Endpoint protegido por JWT: DELETE /api/auth/delete
✅ Confirmación obligatoria en body: { "confirmation": "eliminar" }
✅ Respuestas consistentes:
   - 200 OK -> { "status": "deleted", "message": "Tu cuenta ha sido eliminada." }
   - 400 Bad Request -> { "status": "rejected", "message": "Debes escribir 'eliminar' para confirmar." }
   - 401/403 -> { "status": "forbidden", "message": "No fue posible eliminar la cuenta." }
✅ Integración con Supabase Admin: DELETE /auth/v1/admin/users/{id} usando serviceKey
✅ DTOs incluidos:
   - web/dto/DeleteRequest.java
   - web/dto/DeleteResponse.java
✅ Configuración CORS mantenida (para SPA) y seguridad: anyRequest().authenticated()
