### PR TITLE
Feat: Analytics registros vs la meta de calorias

### DIFF
--- a/src/main/java/com/sebsrvv/app/modules/users/application/IntakeRow.java
+++ b/src/main/java/com/sebsrvv/app/modules/users/application/IntakeRow.java
@@ -1,0 +1,16 @@
+// src/main/java/com/sebsrvv/app/modules/users/application/IntakeRow.java
+package com.sebsrvv.app.modules.users.application;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDate;
+
+public class IntakeRow {
+    @JsonProperty("log_date")
+    public LocalDate logDate;
+
+    @JsonProperty("calories")
+    public Long calories;       // BIGINT en SQL
+
+    @JsonProperty("goal_kcal")
+    public Integer goalKcal;
+}

--- a/src/main/java/com/sebsrvv/app/modules/users/application/UsersAnalyticsService.java
+++ b/src/main/java/com/sebsrvv/app/modules/users/application/UsersAnalyticsService.java
@@ -3,9 +3,10 @@ package com.sebsrvv.app.modules.users.application;
 
 import com.sebsrvv.app.modules.users.web.dto.FoodByCategoryRequest;
 import com.sebsrvv.app.modules.users.web.dto.FoodByCategoryResponse;
+import com.sebsrvv.app.modules.users.web.dto.IntakeVsGoalRequest;
+import com.sebsrvv.app.modules.users.web.dto.IntakeVsGoalResponse;
 import com.sebsrvv.app.supabase.SupabaseDataClient;
 import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
@@ -24,6 +25,8 @@ public class UsersAnalyticsService {
         this.supabase = supabase;
     }
 
+    /* ===================== food-by-category ===================== */
+
     public Mono<FoodByCategoryResponse> foodByCategory(UUID userId,
                                                        FoodByCategoryRequest req,
                                                        String authHeader) {
@@ -34,8 +37,6 @@ public class UsersAnalyticsService {
                 "group_by",  req.getGroupBy()
         );
 
-        // Si viene Authorization del cliente, lo reusamos (modo usuario).
-        // Si no viene, puedes usar service-role (solo dev) o devolver 401.
         Mono<List<FoodRow>> call = (authHeader != null && !authHeader.isBlank())
                 ? supabase.callRpc("food_by_category", payload, authHeader,
                 new ParameterizedTypeReference<List<FoodRow>>() {})
@@ -44,8 +45,6 @@ public class UsersAnalyticsService {
 
         return call.map(rows -> mapToResponse(rows, req));
     }
-
-    /* ---------- mapping igual que antes ---------- */
 
     private FoodByCategoryResponse mapToResponse(List<FoodRow> rows, FoodByCategoryRequest req) {
         FoodByCategoryResponse res = new FoodByCategoryResponse();
@@ -105,9 +104,70 @@ public class UsersAnalyticsService {
     }
 
     private static BigDecimal nz(BigDecimal v) { return v != null ? v : BigDecimal.ZERO; }
+
     private static int safeToInt(long v) {
         if (v > Integer.MAX_VALUE) return Integer.MAX_VALUE;
         if (v < Integer.MIN_VALUE) return Integer.MIN_VALUE;
         return (int) v;
+    }
+
+    /* ===================== intake-vs-goal ===================== */
+
+    public Mono<IntakeVsGoalResponse> intakeVsGoal(UUID userId,
+                                                   IntakeVsGoalRequest req,
+                                                   String authHeader) {
+
+        Map<String, Object> payload = Map.of(
+                "p_user_id", userId.toString(),
+                "from_date", req.getFrom(),
+                "to_date",   req.getTo()
+        );
+
+        Mono<List<IntakeRow>> call = (authHeader != null && !authHeader.isBlank())
+                ? supabase.callRpc("intake_vs_goal", payload, authHeader,
+                new ParameterizedTypeReference<List<IntakeRow>>() {})
+                : supabase.callRpcAsServiceRole("intake_vs_goal", payload,
+                new ParameterizedTypeReference<List<IntakeRow>>() {});
+
+        return call.map(rows -> {
+            IntakeVsGoalResponse res = new IntakeVsGoalResponse();
+
+            int goal = rows.stream()
+                    .map(r -> r.goalKcal != null ? r.goalKcal : 0)
+                    .findFirst().orElse(0);
+            res.goalKcal = goal;
+
+            DateTimeFormatter ISO = DateTimeFormatter.ISO_DATE;
+
+            List<IntakeVsGoalResponse.Day> days = new ArrayList<>();
+            long sumCalories = 0;
+            long sumDelta = 0;
+            int within = 0;
+
+            for (IntakeRow r : rows) {
+                IntakeVsGoalResponse.Day d = new IntakeVsGoalResponse.Day();
+                d.date = r.logDate != null ? r.logDate.format(ISO) : "";
+                int cals = safeToInt(r.calories != null ? r.calories : 0L);
+                d.calories = cals;
+                d.delta = cals - goal;
+
+                sumCalories += cals;
+                sumDelta += d.delta;
+                if (cals <= goal) within++;
+
+                days.add(d);
+            }
+
+            res.days = days;
+
+            IntakeVsGoalResponse.Summary s = new IntakeVsGoalResponse.Summary();
+            int n = Math.max(days.size(), 1); // evitar /0
+            s.daysWithinGoal = within;
+            s.avgCalories = (double) sumCalories / n;
+            s.avgDelta = (double) sumDelta / n;
+
+            res.summary = s;
+            return res;
+        });
     }
 }

--- a/src/main/java/com/sebsrvv/app/modules/users/web/MetricsController.java
+++ b/src/main/java/com/sebsrvv/app/modules/users/web/MetricsController.java
@@ -4,8 +4,10 @@ package com.sebsrvv.app.modules.users.web;
 import com.sebsrvv.app.modules.users.application.MetricsService;
 import com.sebsrvv.app.modules.users.application.UsersAnalyticsService;
 import com.sebsrvv.app.modules.users.web.dto.FoodByCategoryRequest;
+import com.sebsrvv.app.modules.users.web.dto.IntakeVsGoalRequest;
+import com.sebsrvv.app.modules.users.web.dto.IntakeVsGoalResponse;
 import jakarta.validation.Valid;
-import org.springframework.http.HttpHeaders;           // 👈 FALTA ESTE IMPORT
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -28,10 +30,6 @@ public class MetricsController {
         this.analyticsService = analyticsService;
     }
 
-    /**
-     * GET /api/metrics?dob=yyyy-MM-dd&height_cm=170&weight_kg=70
-     * Público. (Aquí se asume service sincrónico como lo tenías)
-     */
     @GetMapping("/metrics")
     public ResponseEntity<Map<String, Object>> getMetrics(
             @RequestParam String dob,
@@ -42,10 +40,6 @@ public class MetricsController {
         return ResponseEntity.ok(success(data));
     }
 
-    /**
-     * POST /api/users/{userId}/analytics/food-by-category
-     * Requiere autenticación. Reenvía el Authorization recibido hacia Supabase.
-     */
     @PostMapping("/users/{userId}/analytics/food-by-category")
     public Mono<ResponseEntity<Map<String, Object>>> foodByCategory(
             @PathVariable UUID userId,
@@ -53,16 +47,21 @@ public class MetricsController {
             @RequestBody @Valid FoodByCategoryRequest body
     ) {
         return analyticsService.foodByCategory(userId, body, authHeader)
-                .map(data -> Map.of(
-                        "ok", true,
-                        "data", data,
-                        "status", 200,
-                        "timestamp", Instant.now().toString()
-                ))
+                .map(data -> Map.of("ok", true, "data", data, "status", 200, "timestamp", Instant.now().toString()))
                 .map(ResponseEntity::ok);
     }
 
-    /* ---------- respuesta success uniforme ---------- */
+    @PostMapping("/users/{userId}/analytics/intake-vs-goal")
+    public Mono<ResponseEntity<Map<String, Object>>> intakeVsGoal(
+            @PathVariable UUID userId,
+            @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authHeader,
+            @RequestBody @Valid IntakeVsGoalRequest body
+    ) {
+        return analyticsService.intakeVsGoal(userId, body, authHeader)
+                .map((IntakeVsGoalResponse data) -> Map.of("ok", true, "data", data, "status", 200, "timestamp", Instant.now().toString()))
+                .map(ResponseEntity::ok);
+    }
+
     private Map<String, Object> success(Object data) {
         return Map.of(
                 "ok", true,

--- a/src/main/java/com/sebsrvv/app/modules/users/web/dto/IntakeVsGoalRequest.java
+++ b/src/main/java/com/sebsrvv/app/modules/users/web/dto/IntakeVsGoalRequest.java
@@ -1,0 +1,20 @@
+// src/main/java/com/sebsrvv/app/modules/users/web/dto/IntakeVsGoalRequest.java
+package com.sebsrvv.app.modules.users.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public class IntakeVsGoalRequest {
+    @NotBlank
+    @Pattern(regexp = "\\d{4}-\\d{2}-\\d{2}")
+    private String from;
+
+    @NotBlank
+    @Pattern(regexp = "\\d{4}-\\d{2}-\\d{2}")
+    private String to;
+
+    public String getFrom() { return from; }
+    public void setFrom(String from) { this.from = from; }
+    public String getTo() { return to; }
+    public void setTo(String to) { this.to = to; }
+}

--- a/src/main/java/com/sebsrvv/app/modules/users/web/dto/IntakeVsGoalResponse.java
+++ b/src/main/java/com/sebsrvv/app/modules/users/web/dto/IntakeVsGoalResponse.java
@@ -1,0 +1,22 @@
+// src/main/java/com/sebsrvv/app/modules/users/web/dto/IntakeVsGoalResponse.java
+package com.sebsrvv.app.modules.users.web.dto;
+
+import java.util.List;
+
+public class IntakeVsGoalResponse {
+    public int goalKcal;
+
+    public static class Day {
+        public String date;     // YYYY-MM-DD
+        public int calories;
+        public int delta;       // calories - goalKcal
+    }
+    public List<Day> days;
+
+    public static class Summary {
+        public int daysWithinGoal;   // calories <= goalKcal
+        public double avgCalories;
+        public double avgDelta;
+    }
+    public Summary summary;
+}


### PR DESCRIPTION
PR: Analytics – Ingesta vs Meta (reactivo + Supabase RPC)

Objetivo: agregar el endpoint analítico que compara la ingesta diaria de calorías del usuario contra su meta (goal_kcal) en un rango de fechas, integrando WebFlux con Supabase RPC.

✅ Endpoint POST /api/users/{userId}/analytics/intake-vs-goal
✅ Cliente Supabase (SupabaseDataClient) con Authorization dinámico (reenviamos el JWT del usuario o service-role en dev)
✅ Servicio UsersAnalyticsService.intakeVsGoal(...) que llama el RPC public.intake_vs_goal y arma el DTO
✅ Nueva DTO IntakeVsGoalRequest / IntakeVsGoalResponse