### PR TITLE
Feat: Analytics progreso semanal de metas

### DIFF
--- a/src/main/java/com/sebsrvv/app/modules/users/application/GoalWeeklyRow.java
+++ b/src/main/java/com/sebsrvv/app/modules/users/application/GoalWeeklyRow.java
@@ -1,0 +1,22 @@
+// src/main/java/com/sebsrvv/app/modules/users/application/GoalWeeklyRow.java
+package com.sebsrvv.app.modules.users.application;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.UUID;
+
+public class GoalWeeklyRow {
+    @JsonProperty("goal_id")
+    public UUID goalId;
+
+    @JsonProperty("goal_name")
+    public String goalName;
+
+    @JsonProperty("weekly_target")
+    public Integer weeklyTarget;
+
+    @JsonProperty("completed_this_week")
+    public Integer completedThisWeek;
+
+    @JsonProperty("progress_percent")
+    public Double progressPercent;
+}

--- a/src/main/java/com/sebsrvv/app/modules/users/web/MetricsController.java
+++ b/src/main/java/com/sebsrvv/app/modules/users/web/MetricsController.java
@@ -1,6 +1,8 @@
 // src/main/java/com/sebsrvv/app/modules/users/web/MetricsController.java
 package com.sebsrvv.app.modules.users.web;
 
+import com.sebsrvv.app.modules.users.web.dto.GoalsWeeklyItem;
+import org.springframework.http.HttpHeaders;
 import com.sebsrvv.app.modules.users.application.MetricsService;
 import com.sebsrvv.app.modules.users.application.UsersAnalyticsService;
 import com.sebsrvv.app.modules.users.web.dto.FoodByCategoryRequest;
@@ -38,6 +40,22 @@ public class MetricsController {
     ) {
         Map<String, Object> data = metricsService.compute(dob, heightCm, weightKg);
         return ResponseEntity.ok(success(data));
+    }
+
+    @GetMapping("/users/{userId}/analytics/goals-weekly")
+    public Mono<ResponseEntity<Map<String, Object>>> goalsWeekly(
+            @PathVariable UUID userId,
+            @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authHeader,
+            @RequestParam(name = "weekStart") String weekStart  // YYYY-MM-DD
+    ) {
+        return analyticsService.goalsWeekly(userId, weekStart, authHeader)
+                .map((java.util.List<GoalsWeeklyItem> data) -> java.util.Map.of(
+                        "ok", true,
+                        "data", data, // lista de objetivos con progreso semanal
+                        "status", 200,
+                        "timestamp", java.time.Instant.now().toString()
+                ))
+                .map(ResponseEntity::ok);
     }
 
     @GetMapping("/users/{userId}/analytics/food-by-category")

--- a/src/main/java/com/sebsrvv/app/modules/users/web/dto/GoalsWeeklyItem.java
+++ b/src/main/java/com/sebsrvv/app/modules/users/web/dto/GoalsWeeklyItem.java
@@ -1,0 +1,12 @@
+// src/main/java/com/sebsrvv/app/modules/users/web/dto/GoalsWeeklyItem.java
+package com.sebsrvv.app.modules.users.web.dto;
+
+import java.util.UUID;
+
+public class GoalsWeeklyItem {
+    public UUID goalId;
+    public String goalName;
+    public int weeklyTarget;
+    public int completedThisWeek;
+    public double progressPercent;
+}


### PR DESCRIPTION
PR: Analytics – Progreso semanal de metas (goals-weekly)

✅ Nuevo endpoint GET /api/users/{userId}/analytics/goals-weekly?weekStart=YYYY-MM-DD
✅ Cliente Supabase con Authorization dinámico (reenvío del JWT de usuario o service_role en dev)
✅ Servicio UsersAnalyticsService.goalsWeekly(...) que invoca el RPC public.goals_weekly
✅ DTOs: GoalWeeklyRow (interno) y GoalsWeeklyItem (respuesta API)
